### PR TITLE
Replace method. Custom connect arguments.

### DIFF
--- a/dblite/dblite.py
+++ b/dblite/dblite.py
@@ -4,8 +4,8 @@ import sqlite3, aiosqlite
 from async_class import AsyncObject
 
 class dbLite(object):
-    def __init__(self, db_name):
-        self.conn = sqlite3.connect(db_name, isolation_level=None, check_same_thread=False)
+    def __init__(self, db_name, isolation_level=None, check_same_thread=False, **kwargs):
+        self.conn = sqlite3.connect(db_name, isolation_level=isolation_level, check_same_thread=check_same_thread, **kwargs)
         self.cursor = self.conn.cursor()
         self.cursor.execute('PRAGMA journal_mode = OFF;')
         self.cursor.execute('PRAGMA synchronous = 0;')
@@ -28,6 +28,13 @@ class dbLite(object):
         col = ', '.join(list(kwargs.keys()))
         val = ', '.join('?' * len(list(kwargs.values())))
         query = f"INSERT INTO {table_name} ({col}) VALUES ({val})"
+        self.cursor.execute(query, tuple(list(kwargs.values())))
+        self.conn.commit()
+
+    def replace(self, table_name, **kwargs):
+        col = ', '.join(list(kwargs.keys()))
+        val = ', '.join('?' * len(list(kwargs.values())))
+        query = f"REPLACE INTO {table_name} ({col}) VALUES ({val})"
         self.cursor.execute(query, tuple(list(kwargs.values())))
         self.conn.commit()
 
@@ -71,8 +78,8 @@ class dbLite(object):
         self.close()
 
 class aioDbLite(AsyncObject):
-    async def __ainit__(self, db_name):
-        self.conn = await aiosqlite.connect(db_name, isolation_level=None, check_same_thread=False)
+    async def __ainit__(self, db_name, isolation_level=None, check_same_thread=False, **kwargs):
+        self.conn = await aiosqlite.connect(db_name, isolation_level=isolation_level, check_same_thread=check_same_thread, **kwargs)
         self.cursor = await self.conn.cursor()
         await self.cursor.execute('PRAGMA journal_mode = OFF;')
         await self.cursor.execute('PRAGMA synchronous = 0;')
@@ -95,6 +102,13 @@ class aioDbLite(AsyncObject):
         col = ', '.join(list(kwargs.keys()))
         val = ', '.join('?' * len(list(kwargs.values())))
         query = f"INSERT INTO {table_name} ({col}) VALUES ({val})"
+        await self.cursor.execute(query, tuple(list(kwargs.values())))
+        await self.conn.commit()
+
+    async def replace(self, table_name, **kwargs):
+        col = ', '.join(list(kwargs.keys()))
+        val = ', '.join('?' * len(list(kwargs.values())))
+        query = f"REPLACE INTO {table_name} ({col}) VALUES ({val})"
         await self.cursor.execute(query, tuple(list(kwargs.values())))
         await self.conn.commit()
 


### PR DESCRIPTION
This fix for not passing isolation_level and check_same_thread arguments to connect function and now it possible to pass custom arguments:


 ```python
aiodb = await aioDbLite('custom.db', detect_types=sqlite3.PARSE_DECLTYPES|sqlite3.PARSE_COLNAMES)
```
Also new replace method is very useful in tables where primary key is not autoincremented.